### PR TITLE
fix for subset-issues in origamiez theme

### DIFF
--- a/google-webfont-optimizer.php
+++ b/google-webfont-optimizer.php
@@ -91,6 +91,16 @@ class GWFO {
                         if (isset($urlParameters['subset'])) {
                             # Use the subset parameter for a subset
                             $subset = $urlParameters['subset'];
+                        } else if (strpos($fontFamily[1],"subset")!==false) {
+                            /* 
+                            * ugly workaround for subset not being parsed out to 
+                            * $urlParameters['subset'] or $fontFamily[2]
+                            * as seen in Origamiez theme
+                            */
+                            $fontFamily[1]="variants=".$fontFamily[1];
+                            parse_str($fontFamily[1],$fontBrakeDown);
+                            $fontFamily[1]=$fontBrakeDown["variants"];
+                            $subset=$fontBrakeDown["subset"];
                         } else {
                             if (isset($fontFamily[2])) {
                                 # Use the subset in the family string


### PR DESCRIPTION
When using [origamiez-theme](https://wordpress.org/themes/origamiez/), "subset" wasn't parsed out successfully, leading to multiple ?subset= in the querystring resulting in a 400-error when requesting the CSS-file from Google. This (ugly) workaround fixes that.

frank
